### PR TITLE
feat!: Migrate everything to .NET 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,14 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Setup .NET 7 preview
-      run: |
-        Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-        ./dotnet-install.ps1 -Channel 7.0.1xx -Quality preview
-      shell: pwsh
+    - name: Setup .NET 7 SDK preview
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '7.0.x'
+        dotnet-quality: 'preview'
+
+    - name: Setup .NET WASM workload
+      run: dotnet workload install wasm-experimental
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
@@ -64,7 +67,7 @@ jobs:
       run: dotnet cake build.cake --target=InstallWorkload --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
 
     - name: Build and publish sample app
-      run: dotnet publish sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj --configuration $env:BUILD_CONFIG -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} --framework=net6.0-browser
+      run: dotnet publish sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj --configuration $env:BUILD_CONFIG -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} --framework=net7.0-browser
 
     - name: Publish sample app artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Setup .NET
+    - name: Setup .NET 7 preview
       run: |
         Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-        ./dotnet-install.ps1 -Channel Current
+        ./dotnet-install.ps1 -Channel 7.0.1xx -Quality preview
       shell: pwsh
 
     - name: Setup MSBuild
@@ -70,7 +70,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: sample_app
-        path: sample/Trungnt2910.Browser.Sample/bin/${{ env.BUILD_CONFIG }}/net6.0-browser/win-x64/publish
+        path: sample/Trungnt2910.Browser.Sample/bin/${{ env.BUILD_CONFIG }}/net7.0-browser/browser-wasm/AppBundle
 
     - name: Publish nuget artifacts
       uses: actions/upload-artifact@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,11 @@
 <Project>
   <PropertyGroup>
-    <_BrowserVersion Condition=" '$(_BrowserVersion)' == '' ">1.0</_BrowserVersion>
-    <_BrowserNetVersion Condition=" '$(_BrowserNetVersion)' == '' ">6.0</_BrowserNetVersion>
+    <_BrowserVersion Condition=" '$(_BrowserVersion)' == '' ">0.1</_BrowserVersion>
+    <_BrowserNetVersion Condition=" '$(_BrowserNetVersion)' == '' ">7.0</_BrowserNetVersion>
     <_BrowserTfm>net$(_BrowserNetVersion)-browser</_BrowserTfm>
     <_BrowserFullTfm>net$(_BrowserNetVersion)-browser$(_BrowserVersion)</_BrowserFullTfm>
     <_BrowserRootDirectory>$(MSBuildThisFileDirectory)</_BrowserRootDirectory>
-    <_BrowserUnoBootstrapVersion Condition=" '$(_BrowserUnoBootstrapVersion)' == '' ">4.0.0-dev.193</_BrowserUnoBootstrapVersion>
-    <_BrowserUnoFoundationVersion Condition=" '$(_BrowserUnoFoundationVersion)' == '' ">4.5.12</_BrowserUnoFoundationVersion>
-    <_BrowserManifestVersionBand Condition=" '$(_BrowserManifestVersionBand)' == '' ">6.0.200</_BrowserManifestVersionBand>
+    <_BrowserMonoWasmVersion Condition=" '$(_BrowserMonoWasmVersion)' == '' ">7.0.0-rc.2.22472.3</_BrowserMonoWasmVersion>
+    <_BrowserManifestVersionBand Condition=" '$(_BrowserManifestVersionBand)' == '' ">7.0.100</_BrowserManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/DotnetBrowser.sln
+++ b/DotnetBrowser.sln
@@ -10,8 +10,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workload", "workload", "{3E
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AF0C9862-1AB0-46F2-BB93-02353ACAB8E9}"
 	ProjectSection(SolutionItems) = preProject
+		build.cake = build.cake
 		Directory.Build.props = Directory.Build.props
 		DotnetBrowser.snk = DotnetBrowser.snk
+		global.json = global.json
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# Dotnet Browser - custom TFM and workload for .NET 6
+# Dotnet Browser - custom TFM and workload for .NET 7
 
-An attempt to create a .NET SDK workload that provides the `net6.0-browser` TFM.
+An attempt to create a .NET SDK workload that provides the `net7.0-browser` TFM.
 
 ## Features
 - Run .NET applications in the browser.
-- Multi-target .NET applications and libraries with other platforms, using the browser-specific `net6.0-browser` TFM.
+- Multi-target .NET applications and libraries with other platforms, using the browser-specific `net7.0-browser` TFM.
 - Access JavaScript APIs (work in progress)
 
 ## How to install
+.NET SDK 7.0 or later is required.
+
 Use `cake` to build this project (on a privileged shell):
 
 ```
@@ -16,13 +18,13 @@ dotnet cake build.cake --target=InstallWorkload
 ```
 
 ## How to use in your projects
-Simply set your project's `TargetFramework` to `net6.0-browser`:
+Simply set your project's `TargetFramework` to `net7.0-browser`:
 
 ```xml
-    <TargetFramework>net6.0-browser</TargetFramework>
+    <TargetFramework>net7.0-browser</TargetFramework>
 ```
 
-In the future you might need to replace `6.0` with the .NET version you're using.
+In the future you might need to replace `7.0` with the .NET version you're using.
 
 ## Sample project
 The repo includes a sample project that multi-targets Windows and Browser WebAssembly.
@@ -56,7 +58,7 @@ document.Paste += (sender, clipboardEvent) =>
 
     if (!string.IsNullOrEmpty(text))
     {
-        Console.WriteLine($"Pasted string: \"{Uno.Foundation.WebAssemblyRuntime.EscapeJs(text)}\"");
+        Console.WriteLine($"Pasted string: {text}");
     }
     else
     {
@@ -71,8 +73,11 @@ Imagine the pain of building Uno Platform applications and/or libraries and then
 Using this project, a single multi-targeted project can be created:
 
 ```xml
-    <TargetFrameworks>net6.0-gtk;net6.0-browser;net6.0-windows7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0-gtk;net7.0-browser;net7.0-windows7.0</TargetFrameworks>
 ```
+
+## What happened to `net6.0-browser`?
+.NET 6 support has been dropped after moving from Uno-based `Uno.Foundation.WebAssembly` to the official .NET `wasm-experimental` implementation, as `WebAssemblyRuntime` functions heavily depend on the new [`System.Runtime.InteropServices.JavaScript`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.javascript?view=net-7.0&viewFallbackFrom=net-6.0) namespace, which is only available on .NET 7 or later versions.
 
 ## Plans
 - Implement all JavaScript Web API bindings on C#, either manually (easy but time consuming) or generated through TypeScript declarations (very challenging due to the numerous differences between C# and TypeScript).

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ Currently, only a small subset of this API is implemented. You can call the impl
 ```C#
 using Trungnt2910.Browser.Dom;
 
-// The global "window" object can be accessed using Window.Instance 
+// The global "window" object can be accessed using `Window.Instance`
 Console.WriteLine(Window.Instance.Location.Href);
 
 // Alternatively, you can use `Document.FromExpression("window.document")`,
 // or directly access `Window.Instance.Document`.
+// On .NET 7, you can also use `JsObject.FromSystemJSObject(JSHost.GlobalThis)`.
 var document = JsObject.FromExpression("window.document").Cast<Document>();
 
 // `createTextNode` is not implemented yet, so you must manually call the function.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ An attempt to create a .NET SDK workload that provides the `net7.0-browser` TFM.
 - Access JavaScript APIs (work in progress)
 
 ## How to install
-.NET SDK 7.0 or later is required.
+.NET SDK 7.0 or later is required, as well as the additional `wasm-experimental` workload.
 
 Use `cake` to build this project (on a privileged shell):
 
 ```
+dotnet workload install wasm-experimental
 dotnet tool restore
 dotnet cake build.cake --target=InstallWorkload
 ```

--- a/build.cake
+++ b/build.cake
@@ -9,7 +9,7 @@ var configuration = Argument("configuration", "Release");
 var target = Argument("target", "Default");
 
 var msbuildsettings = new DotNetMSBuildSettings();
-var supportedVersionBands = new List<string>() {"6.0.100", "6.0.200", "6.0.300", "6.0.400"};
+var supportedVersionBands = new List<string>() {"7.0.100-rc.2", "7.0.100"};
 
 const string manifestName = "Trungnt2910.NET.Sdk.Browser";
 var manifestPack = $"{manifestName}.Manifest-{TargetEnvironment.DotNetCliFeatureBand}.{packageVersion}.nupkg";

--- a/cake/TargetEnvironment.cake
+++ b/cake/TargetEnvironment.cake
@@ -25,6 +25,7 @@ class TargetEnvironment
     static TargetEnvironment()
     {
         DotNetInstallPath = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+
         if (DotNetInstallPath == null)
         {
             if (OperatingSystem.IsWindows())
@@ -68,7 +69,7 @@ class TargetEnvironment
         }
         else
         {
-            DotNetCliFeatureBand = dotnetVersion.Substring(0, DotNetCliFeatureBand.Length - 2) + "00";
+            DotNetCliFeatureBand = dotnetVersion.Substring(0, dotnetVersion.Length - 2) + "00";
             DotNetCliFeatureBandWithoutPreview = DotNetCliFeatureBand;
         }
 

--- a/sample/Rickroller/Rickroller.csproj
+++ b/sample/Rickroller/Rickroller.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net6.0-browser</TargetFrameworks>
+    <TargetFrameworks>net7.0-windows;net7.0-browser</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Authors>trungnt2910</Authors>

--- a/sample/Trungnt2910.Browser.Sample/Program.cs
+++ b/sample/Trungnt2910.Browser.Sample/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 #if BROWSER
+using System.Runtime.InteropServices.JavaScript;
 using Trungnt2910.Browser;
 using Trungnt2910.Browser.Dom;
 #elif WINDOWS
@@ -25,7 +26,7 @@ textNode.SelectStart += (sender, jsEvent) =>
 
     if (count > 10)
     {
-        Window.Instance.InvokeMember("alert", "Please stop selecting me.");
+        JsObject.FromSystemJSObject(JSHost.GlobalThis).InvokeMember("alert", "Please stop selecting me.");
     }
 
     if (count > 15)

--- a/sample/Trungnt2910.Browser.Sample/Program.cs
+++ b/sample/Trungnt2910.Browser.Sample/Program.cs
@@ -42,7 +42,7 @@ document.Paste += (sender, clipboardEvent) =>
 
     if (!string.IsNullOrEmpty(text))
     {
-        Console.WriteLine($"Pasted string: \"{Uno.Foundation.WebAssemblyRuntime.EscapeJs(text)}\"");
+        Console.WriteLine($"Pasted string: {text}");
     }
     else
     {

--- a/sample/Trungnt2910.Browser.Sample/Properties/launchsettings.json
+++ b/sample/Trungnt2910.Browser.Sample/Properties/launchsettings.json
@@ -7,7 +7,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "http://localhost:5000;https://localhost:5001",
-      "commandLineArgs": "--framework net6.0-browser"
     }
   }
 }

--- a/sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj
+++ b/sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0-browser;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net7.0-browser;net7.0-windows</TargetFrameworks>
     <AppDesignerFolder>Properties</AppDesignerFolder>
   </PropertyGroup>
 

--- a/sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj
+++ b/sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rickroller" Version="0.0.1-dev.0.1" />
+    <PackageReference Include="Rickroller" Version="0.0.1-dev.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Trungnt2910.Browser/Generators/JsObjectGenerator.cs
+++ b/src/Trungnt2910.Browser/Generators/JsObjectGenerator.cs
@@ -26,7 +26,7 @@ internal sealed class JsObjectGenerator: GobieClassGenerator
         /// <returns>A <see cref=""{{ClassName}}""/> representing the expression's result, or <see langword=""null""/> if the expression evaluates to <c>null</c> or <c>undefined</c>.</returns>
         new public static {{ClassName}}? FromExpression(string jsExpression)
         {
-            var objectHandleString = global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""Trungnt2910.Browser.JsObject.ConstructObject({jsExpression})"");
+            var objectHandleString = global::Trungnt2910.Browser.WebAssemblyRuntime.InvokeJS($""Trungnt2910.Browser.JsObject.ConstructObject({jsExpression})"");
             if (objectHandleString == null)
             {
                 return null;

--- a/src/Trungnt2910.Browser/Generators/JsObjectPropertyGenerator.cs
+++ b/src/Trungnt2910.Browser/Generators/JsObjectPropertyGenerator.cs
@@ -24,7 +24,7 @@ internal sealed class JsObjectPropertyGenerator : GobieClassGenerator
         public {{Type}}? {{Name}}
         {
             get => {{Type}}.FromExpression($""{_jsThis}.{{JsName}}"");
-            set => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}} = {value?._jsThis ?? ""null""}"");
+            set => global::Trungnt2910.Browser.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}} = {value?._jsThis ?? ""null""}"");
         }
     ";
 }

--- a/src/Trungnt2910.Browser/Generators/MethodGenerator.cs
+++ b/src/Trungnt2910.Browser/Generators/MethodGenerator.cs
@@ -20,7 +20,7 @@
         /// <summary>
         /// {{Comments}}
         /// </summary>
-        public void {{Name}}(@@PARAMETERS_WITH_TYPE@@) => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}(@@PARAMETERS_TO_JS_OBJECT_STRING@@)"");
+        public void {{Name}}(@@PARAMETERS_WITH_TYPE@@) => global::Trungnt2910.Browser.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}(@@PARAMETERS_TO_JS_OBJECT_STRING@@)"");
     "
 )]
 
@@ -32,6 +32,6 @@
         /// <summary>
         /// {{Comments}}
         /// </summary>
-        public string {{Name}}(@@PARAMETERS_WITH_TYPE@@) => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}(@@PARAMETERS_TO_JS_OBJECT_STRING@@)"");
+        public string? {{Name}}(@@PARAMETERS_WITH_TYPE@@) => global::Trungnt2910.Browser.WebAssemblyRuntime.StringOrNullFromJs($""{_jsThis}.{{JsName}}(@@PARAMETERS_TO_JS_OBJECT_STRING@@)"");
     "
 )]

--- a/src/Trungnt2910.Browser/Generators/NumericPropertyGenerator.cs
+++ b/src/Trungnt2910.Browser/Generators/NumericPropertyGenerator.cs
@@ -23,8 +23,8 @@ internal sealed class NumericPropertyGenerator : GobieClassGenerator
         /// </summary>
         public {{Type}}? {{Name}}
         {
-            get => {{Type}}.Parse(global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}""));
-            set => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}} = {value}"");
+            get => global::Trungnt2910.Browser.WebAssemblyRuntime.{{Type}}OrNullFromJs($""{_jsThis}.{{JsName}}"");
+            set => global::Trungnt2910.Browser.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}} = {value}"");
         }
     ";
 }
@@ -48,6 +48,6 @@ internal sealed class NumericReadOnlyPropertyGenerator : GobieClassGenerator
         /// <summary>
         /// {{Comments}}
         /// </summary>
-        public {{Type}}? {{Name}} => {{Type}}.Parse(global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}""));
+        public {{Type}}? {{Name}} => global::Trungnt2910.Browser.WebAssemblyRuntime.{{Type}}OrNullFromJs($""{_jsThis}.{{JsName}}"");
     ";
 }

--- a/src/Trungnt2910.Browser/Generators/StringPropertyGenerator.cs
+++ b/src/Trungnt2910.Browser/Generators/StringPropertyGenerator.cs
@@ -20,8 +20,8 @@ internal sealed class StringPropertyGenerator : GobieClassGenerator
         /// </summary>
         public string? {{Name}}
         {
-            get => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}"");
-            set => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}} = { ((value == null) ? ""null"" : $""\""{(global::Uno.Foundation.WebAssemblyRuntime.EscapeJs(value))}\"""") } "");
+            get => global::Trungnt2910.Browser.WebAssemblyRuntime.StringOrNullFromJs($""{_jsThis}.{{JsName}}"");
+            set => global::Trungnt2910.Browser.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}} = { ((value == null) ? ""null"" : $""\""{(global::Trungnt2910.Browser.WebAssemblyRuntime.EscapeJs(value))}\"""") } "");
         }
     ";
 }
@@ -42,6 +42,6 @@ internal sealed class StringReadOnlyPropertyGenerator : GobieClassGenerator
         /// <summary>
         /// {{Comments}}
         /// </summary>
-        public string? {{Name}} => global::Uno.Foundation.WebAssemblyRuntime.InvokeJS($""{_jsThis}.{{JsName}}"");
+        public string? {{Name}} => global::Trungnt2910.Browser.WebAssemblyRuntime.StringOrNullFromJs($""{_jsThis}.{{JsName}}"");
     ";
 }

--- a/src/Trungnt2910.Browser/JsObject.cs
+++ b/src/Trungnt2910.Browser/JsObject.cs
@@ -218,7 +218,7 @@ public partial class JsObject : IConvertible
     /// </summary>
     /// <typeparam name="T">Any type that derives from <see cref="JsObject"/>.</typeparam>
     /// <returns>A value of type <typeparamref name="T"/> that represents the same JavaScript object.</returns>
-    public T Cast<T>() where T: JsObject
+    public T Cast<T>() where T : JsObject
     {
         var fromHandle = typeof(T).GetMethod(nameof(FromHandle), BindingFlags.Static | BindingFlags.Public);
         return (T)fromHandle!.Invoke(null, new object[] { JsHandle })!;
@@ -439,6 +439,52 @@ public partial class JsObject : IConvertible
         }
     }
     #endregion
+
+    /// <summary>
+    /// Compares two JavaScript objects for reference equality.
+    /// </summary>
+    /// <param name="left">The first object.</param>
+    /// <param name="right">The second object.</param>
+    /// <returns><see langword="true"/> if the two objects refers to the same underlying JavaScript object.</returns>
+    public static bool operator ==(JsObject? left, JsObject? right)
+    {
+        return left?.JsHandle == right?.JsHandle;
+    }
+
+    /// <summary>
+    /// Checks if the two <see cref="JsObject"/> refers to different underlying JavaScript objects.
+    /// </summary>
+    /// <param name="left">The first object.</param>
+    /// <param name="right">The second object.</param>
+    /// <returns>The result of the comparision.</returns>
+    public static bool operator !=(JsObject? left, JsObject? right)
+    {
+        return !(left == right);
+    }
+
+    /// <summary>
+    /// Checks if the current <see cref="JsObject"/> is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Any object.</param>
+    /// <returns><see langword="true"/> if <paramref name="obj"/> is an equivalent <see cref="JsObject"/> or <see cref="SystemJSObject"/>.</returns>
+    public override bool Equals(object? obj)
+    {
+        if (obj is JsObject jsObject)
+        {
+            return this == jsObject;
+        }
+        else if (obj is SystemJSObject systemJSObject)
+        {
+            return this == FromSystemJSObject(systemJSObject);
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return JsHandle;
+    }
 
     /// <summary>
     /// Finalizes the current managed object. This includes

--- a/src/Trungnt2910.Browser/Trungnt2910.Browser.csproj
+++ b/src/Trungnt2910.Browser/Trungnt2910.Browser.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <Content Include="tsconfig.json" />
+    <Content Include="ts\**\*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Trungnt2910.Browser/Trungnt2910.Browser.csproj
+++ b/src/Trungnt2910.Browser/Trungnt2910.Browser.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsTrimmable>true</IsTrimmable>
     <!-- Ignore those spam warnings to filter out the real problems -->
     <!-- No matching param tag in XML comment; Cref attribute cannot be resolved; Referenced assembly does not have a strong name -->
     <NoWarn>CS1573;CS1574;CS8002</NoWarn>

--- a/src/Trungnt2910.Browser/Trungnt2910.Browser.csproj
+++ b/src/Trungnt2910.Browser/Trungnt2910.Browser.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net$(_BrowserNetVersion)</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Ignore those spam warnings to filter out the real problems -->
@@ -18,21 +19,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
+      <_Parameter1>browser</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.8.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Uno.Foundation.Runtime.WebAssembly" Version="$(_BrowserUnoFoundationVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="WasmScripts\**\*.js" />
+    <EmbeddedResource Include="WasmScripts\*.js">
+      <LogicalName>$(RootNamespace).%(Filename).js</LogicalName>
+    </EmbeddedResource>
     <UpToDateCheckInput Include="ts\**\*" />
     <UpToDateCheckInput Include="tsBindings\**\*" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="LinkerDefinition.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Trungnt2910.Browser/WasmScripts/JsObject.js
+++ b/src/Trungnt2910.Browser/WasmScripts/JsObject.js
@@ -3,10 +3,9 @@ var Trungnt2910;
     var Browser;
     (function (Browser) {
         class JsObject {
-            static ConstructObject(obj) {
+            static CreateHandle(obj) {
                 if (JsObject._referencedObjectsMap.has(obj)) {
                     const index = JsObject._referencedObjectsMap.get(obj);
-                    ++JsObject._referenceCount[index];
                     return index;
                 }
                 if (JsObject._freeIds.size) {
@@ -14,7 +13,7 @@ var Trungnt2910;
                     JsObject._freeIds.delete(index);
                     JsObject.ReferencedObjects[index] = obj;
                     JsObject._referencedObjectsMap.set(obj, index);
-                    JsObject._referenceCount[index] = 1;
+                    JsObject._referenceCount[index] = 0;
                     return index;
                 }
                 if (!obj) {
@@ -23,10 +22,13 @@ var Trungnt2910;
                 JsObject.ReferencedObjects.push(obj);
                 const index = JsObject.ReferencedObjects.length - 1;
                 JsObject._referencedObjectsMap.set(obj, index);
-                JsObject._referenceCount.push(1);
+                JsObject._referenceCount.push(0);
                 return index;
             }
-            static DisposeObject(index) {
+            static IncrementReferenceCount(index) {
+                ++JsObject._referenceCount[index];
+            }
+            static DecrementReferenceCount(index) {
                 if ((--JsObject._referenceCount[index]) === 0) {
                     const oldObj = JsObject.ReferencedObjects[index];
                     delete JsObject.ReferencedObjects[index];
@@ -61,7 +63,7 @@ var Trungnt2910;
             }
             static DispatchEvent(index, type, event) {
                 JsObject._managedDispatchEvent = JsObject._managedDispatchEvent || getDotnetRuntime(0).BINDING.bind_static_method("[Trungnt2910.Browser] Trungnt2910.Browser.Dom.EventTarget:DispatchEvent");
-                JsObject._managedDispatchEvent(index, type, JsObject.ConstructObject(event));
+                JsObject._managedDispatchEvent(index, type, JsObject.CreateHandle(event));
             }
         }
         JsObject.ReferencedObjects = [];

--- a/src/Trungnt2910.Browser/WasmScripts/JsObject.js
+++ b/src/Trungnt2910.Browser/WasmScripts/JsObject.js
@@ -60,7 +60,7 @@ var Trungnt2910;
                 }
             }
             static DispatchEvent(index, type, event) {
-                JsObject._managedDispatchEvent = JsObject._managedDispatchEvent || BINDING.bind_static_method("[Trungnt2910.Browser] Trungnt2910.Browser.Dom.EventTarget:DispatchEvent");
+                JsObject._managedDispatchEvent = JsObject._managedDispatchEvent || getDotnetRuntime(0).BINDING.bind_static_method("[Trungnt2910.Browser] Trungnt2910.Browser.Dom.EventTarget:DispatchEvent");
                 JsObject._managedDispatchEvent(index, type, JsObject.ConstructObject(event));
             }
         }

--- a/src/Trungnt2910.Browser/WebAssemblyRuntime.cs
+++ b/src/Trungnt2910.Browser/WebAssemblyRuntime.cs
@@ -1,0 +1,147 @@
+﻿using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.JavaScript;
+using System.Text;
+
+namespace Trungnt2910.Browser;
+
+internal static partial class WebAssemblyRuntime
+{
+    [Pure]
+    public static string EscapeJs(string s)
+    {
+        if (s == null)
+        {
+            return "";
+        }
+
+        bool NeedsEscape(string s2)
+        {
+            for (int i = 0; i < s2.Length; i++)
+            {
+                var c = s2[i];
+
+                if (
+                    c > 255
+                    || c < 32
+                    || c == '\\'
+                    || c == '"'
+                    || c == '\r'
+                    || c == '\n'
+                    || c == '\t'
+                )
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (NeedsEscape(s))
+        {
+            var r = new StringBuilder(s.Length);
+
+            foreach (var c in s)
+            {
+                switch (c)
+                {
+                    case '\\':
+                        r.Append("\\\\");
+                        continue;
+                    case '"':
+                        r.Append("\\\"");
+                        continue;
+                    case '\r':
+                        continue;
+                    case '\n':
+                        r.Append("\\n");
+                        continue;
+                    case '\t':
+                        r.Append("\\t");
+                        continue;
+                }
+
+                if (c < 32)
+                {
+                    continue; // not displayable
+                }
+
+                if (c <= 255)
+                {
+                    r.Append(c);
+                }
+                else
+                {
+                    r.Append("\\u");
+                    r.Append(((ushort)c).ToString("X4"));
+                }
+            }
+
+            return r.ToString();
+        }
+        else
+        {
+            return s;
+        }
+    }
+
+    public static string? InvokeJS(string js)
+    {
+        return StringOrNullFromJs(@$"
+            (function() {{
+                const __result = ({js});
+                if (__result === null || __result === undefined)
+                    return null;
+                if (typeof __result === ""string"")
+                    return __result;
+                if (__result.toString)
+                    return __result.toString();
+                return JSON.stringify(__result);
+            }})();
+        ");
+    }
+
+    [JSImport("globalThis.window.eval")]
+    public static partial string StringFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial string? StringOrNullFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial bool BoolFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial bool BoolOrNullFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial int IntFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial int? IntOrNullFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial double DoubleFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial double? DoubleOrNullFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial JSObject ObjectFromJs(string js);
+
+    [JSImport("globalThis.window.eval")]
+    public static partial JSObject? ObjectOrNullFromJs(string js);
+
+    #region Generator Helpers
+    // These methods exist to serve code generators only.
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool? boolOrNullFromJs(string js) => BoolOrNullFromJs(js);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int? intOrNullFromJs(string js) => IntOrNullFromJs(js);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double? doubleOrNullFromJs(string js) => DoubleOrNullFromJs(js);
+    #endregion
+}

--- a/src/Trungnt2910.Browser/ts/JsObject.ts
+++ b/src/Trungnt2910.Browser/ts/JsObject.ts
@@ -17,10 +17,9 @@ namespace Trungnt2910.Browser {
         private static readonly _objectsWithEvents = new Map<number, Map<string, EventListener>>();
         private static _managedDispatchEvent: (index: number, type: string, eventHandle: number) => void;
 
-        public static ConstructObject(obj: any): number | null {
+        public static CreateHandle(obj: any): number | null {
             if (JsObject._referencedObjectsMap.has(obj)) {
                 const index = JsObject._referencedObjectsMap.get(obj);
-                ++JsObject._referenceCount[index];
                 return index;
             }
 
@@ -29,7 +28,7 @@ namespace Trungnt2910.Browser {
                 JsObject._freeIds.delete(index);
                 JsObject.ReferencedObjects[index] = obj;
                 JsObject._referencedObjectsMap.set(obj, index);
-                JsObject._referenceCount[index] = 1;
+                JsObject._referenceCount[index] = 0;
                 return index;
             }
 
@@ -40,11 +39,15 @@ namespace Trungnt2910.Browser {
             JsObject.ReferencedObjects.push(obj);
             const index = JsObject.ReferencedObjects.length - 1;
             JsObject._referencedObjectsMap.set(obj, index);
-            JsObject._referenceCount.push(1);
+            JsObject._referenceCount.push(0);
             return index;
         }
 
-        public static DisposeObject(index: number) {
+        public static IncrementReferenceCount(index: number) {
+            ++JsObject._referenceCount[index];
+        }
+
+        public static DecrementReferenceCount(index: number) {
             if ((--JsObject._referenceCount[index]) === 0) {
                 const oldObj = JsObject.ReferencedObjects[index];
                 delete JsObject.ReferencedObjects[index];
@@ -82,7 +85,7 @@ namespace Trungnt2910.Browser {
 
         private static DispatchEvent(index: number, type: string, event: Event) {
             JsObject._managedDispatchEvent = JsObject._managedDispatchEvent || getDotnetRuntime(0).BINDING.bind_static_method("[Trungnt2910.Browser] Trungnt2910.Browser.Dom.EventTarget:DispatchEvent");
-            JsObject._managedDispatchEvent(index, type, JsObject.ConstructObject(event));
+            JsObject._managedDispatchEvent(index, type, JsObject.CreateHandle(event));
         }
     }
 }

--- a/src/Trungnt2910.Browser/ts/JsObject.ts
+++ b/src/Trungnt2910.Browser/ts/JsObject.ts
@@ -1,6 +1,12 @@
-﻿declare var BINDING: {
+﻿declare interface Binding {
     bind_static_method<T>(name: string): T;
-};
+}
+
+declare interface DotnetRuntime {
+    BINDING: Binding
+}
+
+declare function getDotnetRuntime(index: number): DotnetRuntime;
 
 namespace Trungnt2910.Browser {
     export class JsObject {
@@ -75,7 +81,7 @@ namespace Trungnt2910.Browser {
         }
 
         private static DispatchEvent(index: number, type: string, event: Event) {
-            JsObject._managedDispatchEvent = JsObject._managedDispatchEvent || BINDING.bind_static_method("[Trungnt2910.Browser] Trungnt2910.Browser.Dom.EventTarget:DispatchEvent");
+            JsObject._managedDispatchEvent = JsObject._managedDispatchEvent || getDotnetRuntime(0).BINDING.bind_static_method("[Trungnt2910.Browser] Trungnt2910.Browser.Dom.EventTarget:DispatchEvent");
             JsObject._managedDispatchEvent(index, type, JsObject.ConstructObject(event));
         }
     }

--- a/workload/Shared/Frameworks.targets
+++ b/workload/Shared/Frameworks.targets
@@ -14,7 +14,7 @@
     <ItemGroup>
       <_RootAttribute Include="Name" Value="Dotnet Browser" />
       <_RootAttribute Include="TargetFrameworkIdentifier" Value=".NETCoreApp" />
-      <_RootAttribute Include="TargetFrameworkVersion" Value="6.0" />
+      <_RootAttribute Include="TargetFrameworkVersion" Value="$(_BrowserNetVersion)" />
       <_RootAttribute Include="FrameworkName" Value="$(MSBuildProjectName.Replace('.Ref','').Replace('.Runtime',''))" />
       <_AssemblyFiles Include="@(_PackageFiles)" Condition=" '%(_PackageFiles.Extension)' == '.dll' and '%(_PackageFiles.SubFolder)' == '' " />
       <_Classifications Include="@(_AssemblyFiles->'%(FileName)%(Extension)'->Distinct())" Profile="Browser" />
@@ -25,7 +25,7 @@
         Files="@(_AssemblyFiles)"
         FileClassifications="@(_Classifications)"
         TargetFile="%(_FrameworkListFile.Identity)"
-        TargetFilePrefixes="ref;lib"
+        TargetFilePrefixes="ref;runtimes/browser-wasm/lib"
         RootAttributes="@(_RootAttribute)"
     />
     <ItemGroup>

--- a/workload/Trungnt2910.Browser.Ref/Trungnt2910.Browser.Ref.csproj
+++ b/workload/Trungnt2910.Browser.Ref/Trungnt2910.Browser.Ref.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <None Include="$(_BrowserRootDirectory)src/Trungnt2910.Browser/bin/$(Configuration)/net$(_BrowserNetVersion)/Trungnt2910.Browser.dll" />
     <None Include="$(_BrowserRootDirectory)src/Trungnt2910.Browser/bin/$(Configuration)/net$(_BrowserNetVersion)/Trungnt2910.Browser.xml" />
-    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="ref/$(_BrowserFullTfm)/%(FileName)%(Extension)" />
-    <_PackageFiles Include="@(None)" PackagePath="ref/$(_BrowserFullTfm)" TargetPath="ref/$(_BrowserFullTfm)" />
+    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="ref/net$(_BrowserNetVersion)/%(FileName)%(Extension)" />
+    <_PackageFiles Include="@(None)" PackagePath="ref/net$(_BrowserNetVersion)" TargetPath="ref/net$(_BrowserNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/workload/Trungnt2910.Browser.Runtime/Trungnt2910.Browser.Runtime.csproj
+++ b/workload/Trungnt2910.Browser.Runtime/Trungnt2910.Browser.Runtime.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <None Include="$(_BrowserRootDirectory)src/Trungnt2910.Browser/bin/$(Configuration)/net$(_BrowserNetVersion)/Trungnt2910.Browser.dll" />
     <None Include="$(_BrowserRootDirectory)src/Trungnt2910.Browser/bin/$(Configuration)/net$(_BrowserNetVersion)/Trungnt2910.Browser.pdb" />
-    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/$(_BrowserFullTfm)/%(FileName)%(Extension)" />
-    <_PackageFiles Include="@(None)" PackagePath="lib/$(_BrowserFullTfm)" TargetPath="lib/$(_BrowserFullTfm)" />
+    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="runtimes/browser-wasm/lib/net$(_BrowserNetVersion)/%(FileName)%(Extension)" />
+    <_PackageFiles Include="@(None)" PackagePath="runtimes/browser-wasm/lib/net$(_BrowserNetVersion)" TargetPath="runtimes/browser-wasm/lib/net$(_BrowserNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/workload/Trungnt2910.Browser.Sdk/Sdk/Sdk.in.targets
+++ b/workload/Trungnt2910.Browser.Sdk/Sdk/Sdk.in.targets
@@ -53,9 +53,20 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Must be self-contained. Framework-dependent builds cannot see our custom runtime -->
-    <SelfContained>true</SelfContained>
+    <_BrowserIsExe>false</_BrowserIsExe>
+    <_BrowserIsExe Condition="$(OutputType.Equals('exe', StringComparison.InvariantCultureIgnoreCase)) or $(OutputType.Equals('winexe', StringComparison.InvariantCultureIgnoreCase))">true</_BrowserIsExe>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_BrowserIsExe)' == 'true'">
+    <!-- Must be self-contained. Framework-dependent builds cannot see our custom runtime. -->
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_BrowserIsExe)' == 'false'">
+    <!-- The WebAssembly workloads forcefully sets the <OutputType> to Exe. -->
+    <!-- https://github.com/dotnet/runtime/blob/main/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.props#L6 -->
+    <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/workload/Trungnt2910.Browser.Sdk/Sdk/Sdk.in.targets
+++ b/workload/Trungnt2910.Browser.Sdk/Sdk/Sdk.in.targets
@@ -29,7 +29,7 @@
       TargetingPackName="Trungnt2910.Browser.Ref"
       TargetingPackVersion="**FromWorkload**"
       RuntimePackNamePatterns="Trungnt2910.Browser.Runtime"
-      RuntimePackRuntimeIdentifiers="win-x64;win-x86;linux-x64;linux-x86;osx-x64"
+      RuntimePackRuntimeIdentifiers="browser-wasm"
       Profile="Browser"
     />
   </ItemGroup>
@@ -55,38 +55,54 @@
   <PropertyGroup>
     <!-- Must be self-contained. Framework-dependent builds cannot see our custom runtime -->
     <SelfContained>true</SelfContained>
-    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOsPlatform('Windows')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOsPlatform('Windows')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">win-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOsPlatform('Linux')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">linux-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOsPlatform('Linux')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">linux-x86</RuntimeIdentifier>
-    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' and $([MSBuild]::IsOsPlatform('OSX')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">osx-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe' ">
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="@BROWSERUNOBOOTSTRAPVERSION@" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="@BROWSERUNOBOOTSTRAPVERSION@" ExcludeAssets="build" />
-  </ItemGroup>
+  <PropertyGroup>
+    <_WasmMainHTMLName>$([System.IO.Path]::GetFileName('$(WasmMainHTMLPath)'))</_WasmMainHTMLName>
+    <_WasmMainHTMLName Condition="'$(_WasmMainHTMLName)' == ''">index.html</_WasmMainHTMLName>  
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.Foundation.Runtime.WebAssembly" Version="@BROWSERUNOFOUNDATIONVERSION@" />
+    <HostConfig Include="browser" Host="browser" html-path="$(_WasmMainHTMLName)" />
   </ItemGroup>
 
-  <!-- Adapted from https://github.com/unoplatform/Uno.Wasm.Bootstrap/blob/main/src/Uno.Wasm.Bootstrap.DevServer/build/Uno.Wasm.Bootstrap.DevServer.targets -->
-  <!-- The original code does not honor the $(RuntimeIdentifier) value, making it unable to be run on this workload -->
-  <PropertyGroup>
-    <!-- Web Project Run Parameters -->
-    <RunCommand>dotnet</RunCommand>
+  <Target Name="_FixMicrosoftNetCoreAppRuntimePackDir" BeforeTargets="_InitializeCommonProperties">
+    <PropertyGroup>
+      <MicrosoftNetCoreAppRuntimePackDir Condition="'$(MicrosoftNetCoreAppRuntimePackDir)' == ''">$([MSBuild]::NormalizeDirectory(%(ResolvedRuntimePack.PackageDirectory), '..', '..', 'Microsoft.NETCore.App.Runtime.Mono.browser-wasm', '@BROWSERMONOWASMVERSION@'))</MicrosoftNetCoreAppRuntimePackDir>
+    </PropertyGroup>
+  </Target>
 
-    <!-- Nuget deployed run parameters -->
-    <_unoBinArgs>unowasm serve</_unoBinArgs>
+  <Target Name="_WasmGenerateMainJs"
+          Condition="'$(WasmGenerateAppBundle)' == 'true' and '$(WasmMainJSPath)' == ''"
+          BeforeTargets="_WasmGenerateAppBundle"
+          Outputs="$(IntermediateOutputPath)/main.js">
+    <PropertyGroup>
+      <_BrowserDefaultJs>
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
-    <_UnoDevServerBasePath Condition="'$(TargetFramework)'=='netstandard2.0'">netcoreapp3.1</_UnoDevServerBasePath>
-    <_UnoDevServerBasePath Condition="'$(TargetFramework.substring(0,3))'=='net' and '$(TargetFramework)'!='netstandard2.0'">net5</_UnoDevServerBasePath>
-    <_UnoDevServerBasePath Condition="'$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))' &gt; 5">net6</_UnoDevServerBasePath>
+import { dotnet } from './dotnet.js'
 
-    <!-- Uno.Wasm.Bootstrap internal args -->
-    <_unoBinArgs>&quot;$(NuGetPackageRoot)/uno.wasm.bootstrap.devserver/@BROWSERUNOBOOTSTRAPVERSION@/tools/server/$(_UnoDevServerBasePath)/dotnet-unowasm.dll&quot; serve $(_unoRunArgs)</_unoBinArgs>
-    <RunArguments>$(_unoBinArgs) $(_unoRunArgs) --pathbase &quot;$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\dist&quot; --configuration $(Configuration) --targetframework $(TargetFramework) $(AdditionalRunArguments)</RunArguments>
-  </PropertyGroup>
+const is_browser = typeof window != &quot;undefined&quot;;
+if (!is_browser) throw new Error(`Expected to be running in a browser`);
+
+const runtime = await dotnet
+    .withDiagnosticTracing(false)
+    .withApplicationArgumentsFromQuery()
+    .create();
+
+const config = runtime.getConfig();
+await runtime.runMainAndExit(config.mainAssemblyName, []);
+      </_BrowserDefaultJs>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(IntermediateOutputPath)/main.js" Lines="$(_BrowserDefaultJs)" Overwrite="true"/>
+    <PropertyGroup>
+      <WasmMainJSPath>$(IntermediateOutputPath)/main.js</WasmMainJSPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <WasmExtraFilesToDeploy Include="$(WasmMainJSPath)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/workload/Trungnt2910.Browser.Sdk/Trungnt2910.Browser.Sdk.csproj
+++ b/workload/Trungnt2910.Browser.Sdk/Trungnt2910.Browser.Sdk.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Shared/Common.targets" />
 
   <PropertyGroup>
-    <Description>Dotnet Browser SDK. Enabled via the net6.0-browser TFM.</Description>
+    <Description>Dotnet Browser SDK. Enabled via the net7.0-browser TFM.</Description>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,9 +19,7 @@
 
     <ReplaceText Input="$(IntermediateOutputPath)Sdk.targets" Output="$(IntermediateOutputPath)Sdk.targets" OldValue="@BROWSERNETVERSION@" NewValue="$(_BrowserNetVersion)" />
 
-    <ReplaceText Input="$(IntermediateOutputPath)Sdk.targets" Output="$(IntermediateOutputPath)Sdk.targets" OldValue="@BROWSERUNOFOUNDATIONVERSION@" NewValue="$(_BrowserUnoFoundationVersion)" />
-
-    <ReplaceText Input="$(IntermediateOutputPath)Sdk.targets" Output="$(IntermediateOutputPath)Sdk.targets" OldValue="@BROWSERUNOBOOTSTRAPVERSION@" NewValue="$(_BrowserUnoBootstrapVersion)" />
+    <ReplaceText Input="$(IntermediateOutputPath)Sdk.targets" Output="$(IntermediateOutputPath)Sdk.targets" OldValue="@BROWSERMONOWASMVERSION@" NewValue="$(_BrowserMonoWasmVersion)" />
 
     <ItemGroup>
       <None Include="$(IntermediateOutputPath)Sdk.targets" Link="Sdk/Sdk.targets" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="Sdk" Visible="false" />

--- a/workload/Trungnt2910.NET.Sdk.Browser/Trungnt2910.NET.Sdk.Browser.csproj
+++ b/workload/Trungnt2910.NET.Sdk.Browser/Trungnt2910.NET.Sdk.Browser.csproj
@@ -21,12 +21,26 @@
       BeforeTargets="Build;AssignTargetPaths"
       Inputs="$(MSBuildProjectFile);WorkloadManifest.in.json"
       Outputs="$(IntermediateOutputPath)WorkloadManifest.json">
-    
+
     <ReplaceText
         Input="WorkloadManifest.in.json"
         Output="$(IntermediateOutputPath)WorkloadManifest.json"
         OldValue="@VERSION@"
         NewValue="$(PackageVersion)"
+    />
+
+    <ReplaceText
+        Input="$(IntermediateOutputPath)WorkloadManifest.json"
+        Output="$(IntermediateOutputPath)WorkloadManifest.json"
+        OldValue="@BROWSERNETMAJORVERSION@"
+        NewValue="$([System.Version]::Parse($(_BrowserNetVersion)).ToString(1))"
+    />
+
+    <ReplaceText
+        Input="$(IntermediateOutputPath)WorkloadManifest.json"
+        Output="$(IntermediateOutputPath)WorkloadManifest.json"
+        OldValue="@BROWSERMONOWASMVERSION@"
+        NewValue="$(_BrowserMonoWasmVersion)"
     />
 
     <ItemGroup>
@@ -39,7 +53,7 @@
       />
       <FileWrites Include="$(IntermediateOutputPath)WorkloadManifest.json" />
     </ItemGroup>
-  
+
   </Target>
 
 </Project>

--- a/workload/Trungnt2910.NET.Sdk.Browser/WorkloadManifest.in.json
+++ b/workload/Trungnt2910.NET.Sdk.Browser/WorkloadManifest.in.json
@@ -1,5 +1,8 @@
 {
     "version": "@VERSION@",
+    "depends-on": {
+      "Microsoft.NET.Workload.Mono.ToolChain.net@BROWSERNETMAJORVERSION@": "@BROWSERMONOWASMVERSION@"
+    },
     "workloads": {
       "browser": {
         "description": ".NET SDK Workload for building Dotnet Browser applications.",
@@ -7,7 +10,9 @@
           "Trungnt2910.Browser.Sdk",
           "Trungnt2910.Browser.Ref",
           "Trungnt2910.Browser.Runtime"
-        ]
+        ],
+        "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
+        "extends" : [ "wasm-experimental" ]
       }
     },
     "packs": {


### PR DESCRIPTION
This commit should remove all Uno Platform dependencies (Uno Platform JavaScript interop, Uno Platform WASM host) and instead use their native .NET 7 counterparts.