### PR TITLE
test: Integrated tests into cake and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       BUILD_CONFIG: 'Release'
 
     runs-on: windows-latest
+    continue-on-error: true
 
     steps:
     - name: Checkout
@@ -73,7 +74,13 @@ jobs:
       uses: browser-actions/setup-edge@latest
 
     - name: Run workload tests
-      run: dotnet cake build.cake --target=RunWorkloadTests --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
+      uses: trungnt2910/retry@6f435f22ad3f826a2fee71d007c8a2bf68022197
+      continue-on-error: true
+      with:
+        timeout_minutes: 15
+        max_attempts: 5
+        retry_on: timeout
+        command: dotnet cake build.cake --target=RunWorkloadTests --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
 
     - name: Build and publish sample app
       run: dotnet publish sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj --configuration $env:BUILD_CONFIG -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} --framework=net7.0-browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
     - name: Build and install workload
       run: dotnet cake build.cake --target=InstallWorkload --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
 
+    - name: Build and package test framework
+      run: dotnet cake build.cake --target=BuildAndPackageTestFramework --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
+
+    - name: Setup Microsoft Edge
+      uses: browser-actions/setup-edge@latest
+
+    - name: Run workload tests
+      run: dotnet cake build.cake --target=RunWorkloadTests --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
+
     - name: Build and publish sample app
       run: dotnet publish sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj --configuration $env:BUILD_CONFIG -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} --framework=net7.0-browser
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,6 @@ jobs:
     - name: Build and package test framework
       run: dotnet cake build.cake --target=BuildAndPackageTestFramework --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
 
-    - name: Setup Microsoft Edge
-      uses: browser-actions/setup-edge@latest
-
-    - name: Run workload tests
-      uses: trungnt2910/retry@6f435f22ad3f826a2fee71d007c8a2bf68022197
-      continue-on-error: true
-      with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_on: timeout
-        command: dotnet cake build.cake --target=RunWorkloadTests --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
-
     - name: Build and publish sample app
       run: dotnet publish sample/Trungnt2910.Browser.Sample/Trungnt2910.Browser.Sample.csproj --configuration $env:BUILD_CONFIG -p:Version=${{ steps.gitversion.outputs.assemblySemVer }} --framework=net7.0-browser
 
@@ -96,6 +84,20 @@ jobs:
       with:
         name: packages.${{ steps.gitversion.outputs.semVer }}
         path: out/nuget/**
+
+    - name: Setup Microsoft Edge
+      uses: browser-actions/setup-edge@latest
+
+    - name: Kick start Microsoft Edge
+      run: msedge
+
+    - name: Run workload tests
+      uses: trungnt2910/retry@98283a392bcde219c965f5ed10e31ec4eef2f4da
+      with:
+        timeout_minutes: 15
+        max_attempts: 5
+        retry_on: timeout
+        command: dotnet cake build.cake --target=RunWorkloadTests --configuration=$env:BUILD_CONFIG --build-version=${{ steps.gitversion.outputs.majorMinorPatch }} --package-version=${{ steps.gitversion.outputs.semVer }}
 
     # - name: Publish dev
     #   if: github.ref == 'refs/heads/master'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/Gobie"]
 	path = src/Gobie
 	url = https://github.com/trungnt2910/Gobie
+[submodule "tests/Trungnt2910.Browser.ObservationFramework"]
+	path = tests/Trungnt2910.Browser.ObservationFramework
+	url = https://github.com/trungnt2910/Trungnt2910.Browser.ObservationFramework

--- a/DotnetBrowser.sln
+++ b/DotnetBrowser.sln
@@ -47,6 +47,24 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Trungnt2910.Browser.PostPro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rickroller", "sample\Rickroller\Rickroller.csproj", "{D8E42155-A196-470D-B236-1D74B642CF69}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6E729401-F6AC-4A4D-A6F6-B200590D82DB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Trungnt2910.Browser.ObservationFramework", "Trungnt2910.Browser.ObservationFramework", "{3822E952-E930-4972-9474-6A6A927C4063}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Trungnt2910.Browser.ObservationFramework\Directory.Build.props = tests\Trungnt2910.Browser.ObservationFramework\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Trungnt2910.Browser.ObservationFramework", "tests\Trungnt2910.Browser.ObservationFramework\Trungnt2910.Browser.ObservationFramework\Trungnt2910.Browser.ObservationFramework.csproj", "{9AF8BE06-E146-4B3E-A2A7-BEC29AE5A1A3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9} = {4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ObservationHost", "tests\Trungnt2910.Browser.ObservationFramework\ObservationHost\ObservationHost.csproj", "{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Trungnt2910.Browser.ObservationFramework.WebSocket.Shared", "tests\Trungnt2910.Browser.ObservationFramework\Trungnt2910.Browser.ObservationFramework.WebSocket.Shared\Trungnt2910.Browser.ObservationFramework.WebSocket.Shared.csproj", "{1E880931-1CEC-438B-B04C-0EE469626B6D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trungnt2910.Browser.Tests", "tests\Trungnt2910.Browser.Tests\Trungnt2910.Browser.Tests.csproj", "{2EC5733C-073A-4689-8655-BBA8862B8312}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +115,22 @@ Global
 		{D8E42155-A196-470D-B236-1D74B642CF69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8E42155-A196-470D-B236-1D74B642CF69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8E42155-A196-470D-B236-1D74B642CF69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AF8BE06-E146-4B3E-A2A7-BEC29AE5A1A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AF8BE06-E146-4B3E-A2A7-BEC29AE5A1A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AF8BE06-E146-4B3E-A2A7-BEC29AE5A1A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AF8BE06-E146-4B3E-A2A7-BEC29AE5A1A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E880931-1CEC-438B-B04C-0EE469626B6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E880931-1CEC-438B-B04C-0EE469626B6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E880931-1CEC-438B-B04C-0EE469626B6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E880931-1CEC-438B-B04C-0EE469626B6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EC5733C-073A-4689-8655-BBA8862B8312}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EC5733C-073A-4689-8655-BBA8862B8312}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EC5733C-073A-4689-8655-BBA8862B8312}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EC5733C-073A-4689-8655-BBA8862B8312}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +149,11 @@ Global
 		{662A79D1-C3CB-4D5D-AC2E-F46C160B8F41} = {00AAA5AE-73A1-4626-AE26-96524BFBFC9C}
 		{23B1FE07-BCD1-4B3C-AA62-D076A0370DC2} = {00AAA5AE-73A1-4626-AE26-96524BFBFC9C}
 		{D8E42155-A196-470D-B236-1D74B642CF69} = {050E2031-DA85-4DD5-AB76-A5D5F2BC4F56}
+		{3822E952-E930-4972-9474-6A6A927C4063} = {6E729401-F6AC-4A4D-A6F6-B200590D82DB}
+		{9AF8BE06-E146-4B3E-A2A7-BEC29AE5A1A3} = {3822E952-E930-4972-9474-6A6A927C4063}
+		{4A9DA42E-5008-48FA-9AB6-1E2CF48CF4D9} = {3822E952-E930-4972-9474-6A6A927C4063}
+		{1E880931-1CEC-438B-B04C-0EE469626B6D} = {3822E952-E930-4972-9474-6A6A927C4063}
+		{2EC5733C-073A-4689-8655-BBA8862B8312} = {6E729401-F6AC-4A4D-A6F6-B200590D82DB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7E38642-D6A3-451F-929A-4CAF0423329C}

--- a/build.cake
+++ b/build.cake
@@ -33,8 +33,7 @@ Task("Init")
     // Assign some common properties
     msbuildsettings = msbuildsettings.WithProperty("Version", version);
     msbuildsettings = msbuildsettings.WithProperty("PackageVersion", packageVersion);
-    msbuildsettings = msbuildsettings.WithProperty("Authors", "'Trung Nguyen'");
-    msbuildsettings = msbuildsettings.WithProperty("PackageLicenseUrl", "'https://github.com/trungnt2910/DotnetBrowser/blob/master/LICENSE'");
+    msbuildsettings = msbuildsettings.WithProperty("Authors", "Trung Nguyen");
     msbuildsettings = msbuildsettings.WithProperty("_BrowserVersion", version);
 });
 
@@ -93,10 +92,10 @@ Task("BuildAndPackageWorkload")
     };
 
     // Clean up the output of the manifest project first, else the old manifest may remain.
-    DotNetClean("workload/Trungnt2910.NET.Sdk.Browser/Trungnt2910.NET.Sdk.Browser.csproj", new DotNetCleanSettings() 
-    { 
+    DotNetClean("workload/Trungnt2910.NET.Sdk.Browser/Trungnt2910.NET.Sdk.Browser.csproj", new DotNetCleanSettings()
+    {
         MSBuildSettings = msbuildsettings,
-        Configuration = configuration 
+        Configuration = configuration
     });
 
     foreach (var name in packNames)
@@ -144,6 +143,32 @@ Task("UninstallWorkload")
     }
     Console.WriteLine($"Unregistering \"browser\" installed workload...");
     TargetEnvironment.UnregisterInstalledWorkload("browser");
+});
+
+Task("BuildAndPackageTestFramework")
+    .IsDependentOn("Init")
+    .Does(() =>
+{
+    var packSettings = new DotNetPackSettings
+    {
+        MSBuildSettings = msbuildsettings,
+        Configuration = configuration,
+        OutputDirectory = "out/nuget",
+    };
+
+    DotNetPack($"tests/Trungnt2910.Browser.ObservationFramework/Trungnt2910.Browser.ObservationFramework/Trungnt2910.Browser.ObservationFramework.csproj", packSettings);
+});
+
+Task("RunWorkloadTests")
+    .IsDependentOn("BuildAndPackageTestFramework")
+    .Does(() =>
+{
+    var testSettings = new DotNetTestSettings
+    {
+        Configuration = configuration,
+    };
+
+    DotNetTest("tests/Trungnt2910.Browser.Tests/Trungnt2910.Browser.Tests.csproj", testSettings);
 });
 
 // TASK TARGETS

--- a/src/Trungnt2910.Browser/JsObject.cs
+++ b/src/Trungnt2910.Browser/JsObject.cs
@@ -137,6 +137,11 @@ public partial class JsObject : IConvertible
         {
             case null:
                 return "null";
+            case bool:
+                // Special case for booleans:
+                // The default C# converter converts a `true` value to `"True"` and `false` value to `"False"`,
+                // but JavaScript uses `"true"` and `"false"` (without a capital letter).
+                return (bool)obj ? "true" : "false";
             case sbyte:
             case byte:
             case short:

--- a/src/Trungnt2910.Browser/WasmScripts/JsObject.js
+++ b/src/Trungnt2910.Browser/WasmScripts/JsObject.js
@@ -19,6 +19,9 @@ var Trungnt2910;
                 JsObject._managedDispatchRejected = exports.Trungnt2910.Browser.Promise.DispatchRejected;
             }
             static CreateHandle(obj) {
+                if (obj === null || obj === undefined) {
+                    return null;
+                }
                 if (JsObject._referencedObjectsMap.has(obj)) {
                     const index = JsObject._referencedObjectsMap.get(obj);
                     if (index === undefined) {
@@ -33,9 +36,6 @@ var Trungnt2910;
                     JsObject._referencedObjectsMap.set(obj, index);
                     JsObject._referenceCount[index] = 0;
                     return index;
-                }
-                if (obj === null || obj === undefined) {
-                    return null;
                 }
                 JsObject.ReferencedObjects.push(obj);
                 const index = JsObject.ReferencedObjects.length - 1;

--- a/src/Trungnt2910.Browser/WasmScripts/JsObject.js
+++ b/src/Trungnt2910.Browser/WasmScripts/JsObject.js
@@ -34,7 +34,7 @@ var Trungnt2910;
                     JsObject._referenceCount[index] = 0;
                     return index;
                 }
-                if (!obj) {
+                if (obj === null || obj === undefined) {
                     return null;
                 }
                 JsObject.ReferencedObjects.push(obj);

--- a/src/Trungnt2910.Browser/ts/JsObject.ts
+++ b/src/Trungnt2910.Browser/ts/JsObject.ts
@@ -56,7 +56,7 @@ namespace Trungnt2910.Browser {
                 return index;
             }
 
-            if (!obj) {
+            if (obj === null || obj === undefined) {
                 return null;
             }
 

--- a/src/Trungnt2910.Browser/ts/JsObject.ts
+++ b/src/Trungnt2910.Browser/ts/JsObject.ts
@@ -39,6 +39,10 @@ namespace Trungnt2910.Browser {
         }
 
         public static CreateHandle(obj: any): number | null {
+            if (obj === null || obj === undefined) {
+                return null;
+            }
+
             if (JsObject._referencedObjectsMap.has(obj)) {
                 const index = JsObject._referencedObjectsMap.get(obj);
                 if (index === undefined) {
@@ -54,10 +58,6 @@ namespace Trungnt2910.Browser {
                 JsObject._referencedObjectsMap.set(obj, index);
                 JsObject._referenceCount[index] = 0;
                 return index;
-            }
-
-            if (obj === null || obj === undefined) {
-                return null;
             }
 
             JsObject.ReferencedObjects.push(obj);

--- a/tests/Trungnt2910.Browser.Tests/Given_IntArray.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_IntArray.cs
@@ -1,0 +1,46 @@
+﻿namespace Trungnt2910.Browser.Tests;
+
+public class Given_IntArray : Specification
+{
+    private JsArray<int> _array = null!;
+
+    protected override void EstablishContext()
+    {
+        _array = JsArray<int>.FromExpression("[1, 2, 3]")!;
+    }
+
+    [Observation]
+    public void When_GetProperties()
+    {
+        Assert.NotNull(_array);
+        Assert.NotEmpty(_array);
+        Assert.Equal(3, _array.Length);
+        Assert.Equal(3, _array.Count);
+    }
+
+    [Observation]
+    public void When_GetElementByIndex()
+    {
+        Assert.Equal(1, _array[0]);
+        Assert.Equal(2, _array[1]);
+        Assert.Equal(3, _array[2]);
+        Assert.ThrowsAny<Exception>(() => _array[3]);
+        Assert.ThrowsAny<Exception>(() => _array[-1]);
+    }
+
+    [Observation]
+    public void When_SetElementFromManagedCode()
+    {
+        Assert.Equal(1, _array[0]);
+        _array[0] = 69420;
+        Assert.Equal(69420, _array[0]);
+        _array[0] = 1;
+        Assert.Equal(1, _array[0]);
+    }
+
+    [Observation]
+    public void When_UsedWithLinq()
+    {
+        Assert.True(_array.SequenceEqual(new[] { 1, 2, 3 }));
+    }
+}

--- a/tests/Trungnt2910.Browser.Tests/Given_IntPromise.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_IntPromise.cs
@@ -1,0 +1,33 @@
+﻿namespace Trungnt2910.Browser.Tests;
+
+public class Given_IntPromise : Specification
+{
+    private Promise<int> _promise1 = null!;
+    private Promise<int> _promise2 = null!;
+
+    protected override void EstablishContext()
+    {
+        _promise1 = Promise<int>.FromExpression("new Promise((resolve, reject) => setTimeout(() => resolve(1), 1000))")!;
+        _promise2 = Promise<int>.FromExpression("new Promise((resolve, reject) => setTimeout(() => resolve(2), 2000))")!;
+    }
+
+    [Observation]
+    public async void When_Await()
+    {
+        Assert.NotNull(_promise1);
+        Assert.Equal(1, await _promise1);
+    }
+
+    [Observation]
+    public async void When_AwaitAgain()
+    {
+        Assert.Equal(1, await _promise1);
+    }
+
+    [Observation]
+    public async void When_UsedWithTaskApi()
+    {
+        var arr = await Task.WhenAll(_promise1, _promise2, Task.FromResult(3));
+        Assert.True(arr.SequenceEqual(new[] { 1, 2, 3 }));
+    }
+}

--- a/tests/Trungnt2910.Browser.Tests/Given_JsFunc.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_JsFunc.cs
@@ -1,0 +1,48 @@
+﻿namespace Trungnt2910.Browser.Tests;
+
+public class Given_JsFunc : Specification
+{
+    private JsFunc<int, int, int> _jsAdd = null!;
+    private Random _random = null!;
+
+    protected override void EstablishContext()
+    {
+        _jsAdd = JsFunc<int, int, int>.FromExpression("(a, b) => a + b")!;
+        _random = new Random();
+    }
+
+    [Observation]
+    public void When_InvokeFunction()
+    {
+        Assert.NotNull(_jsAdd);
+
+        Assert.Equal(2, _jsAdd.Invoke(1, 1));
+        Assert.Equal(-5, _jsAdd.Invoke(1, -6));
+
+        var a = GetJsSafeRandomInt();
+        var b = GetJsSafeRandomInt();
+
+        Assert.Equal(a + b, _jsAdd.Invoke(a, b));
+    }
+
+    [Observation]
+    public void When_UsedAsCsharpDelegate()
+    {
+        var addFunc = (Func<int, int, int>)_jsAdd;
+
+        Assert.NotNull(addFunc);
+
+        Assert.Equal(addFunc(1, 1), _jsAdd.Invoke(1, 1));
+        Assert.Equal(addFunc(1, -6), _jsAdd.Invoke(1, -6));
+
+        var a = GetJsSafeRandomInt();
+        var b = GetJsSafeRandomInt();
+
+        Assert.Equal(addFunc(a, b), _jsAdd.Invoke(a, b));
+    }
+
+    private int GetJsSafeRandomInt()
+    {
+        return _random.Next((int)-1e8, (int)1e8);
+    }
+}

--- a/tests/Trungnt2910.Browser.Tests/Given_JsObject.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_JsObject.cs
@@ -49,4 +49,18 @@ public class Given_JsObject : Specification
         Assert.Equal("true", JsObject.ToJsObjectString(true));
         Assert.Equal("false", JsObject.ToJsObjectString(false));
     }
+
+    [Observation]
+    public void When_UndefinedFromExpressionAfterGarbageCollection()
+    {
+        int? handle = WebAssemblyRuntime.Int32OrNullFromJs("Trungnt2910.Browser.JsObject.CreateHandle({})");
+        Assert.NotNull(handle);
+        // Simulates a JsObject being created.
+        WebAssemblyRuntime.InvokeJS($"Trungnt2910.Browser.JsObject.IncrementReferenceCount({handle})");
+        // Simulates a JsObject being finalized.
+        WebAssemblyRuntime.InvokeJS($"Trungnt2910.Browser.JsObject.DecrementReferenceCount({handle})");
+
+        // Now there should be a "undefined" slot in the JavaScript object pool.
+        Assert.Null(JsObject.FromExpression("undefined"));
+    }
 }

--- a/tests/Trungnt2910.Browser.Tests/Given_JsObject.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_JsObject.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Trungnt2910.Browser.Tests;
+
+public class Given_JsObject : Specification
+{
+    private JsObject _systemGlobalThis = null!;
+    private JsObject _windowInstance = null!;
+    private JsObject _dummy = null!;
+
+    protected override void EstablishContext()
+    {
+        _windowInstance = Window.Instance!;
+        _systemGlobalThis = JsObject.FromSystemJSObject(JSHost.GlobalThis)!;
+        _dummy = JsObject.FromExpression("[]")!;
+    }
+
+    [Observation]
+    public void When_CompareSystemAndLibraryJsObject()
+    {
+        Assert.NotNull(_systemGlobalThis);
+        Assert.NotNull(_windowInstance);
+        Assert.Equal(_systemGlobalThis, _windowInstance);
+        Assert.NotEqual(_systemGlobalThis, _dummy);
+    }
+
+    [Observation]
+    public void When_NullOrUndefinedFromExpression()
+    {
+        Assert.Null(JsObject.FromExpression("undefined"));
+        Assert.Null(JsObject.FromExpression("null"));
+        Assert.NotNull(JsObject.FromExpression("false"));
+        Assert.NotNull(JsObject.FromExpression("0"));
+        Assert.NotNull(JsObject.FromExpression("[]"));
+    }
+
+    [Observation]
+    public void When_SameObjectFromExpression()
+    {
+        // _systemGlobalThis is constructed in JsObject's context.
+        Assert.True(ReferenceEquals(_systemGlobalThis, JsObject.FromExpression("globalThis")));
+        // _windowInstance is constructed in Window's context.
+        Assert.True(ReferenceEquals(_windowInstance, Window.FromExpression("window")));
+    }
+}

--- a/tests/Trungnt2910.Browser.Tests/Given_JsObject.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_JsObject.cs
@@ -42,4 +42,11 @@ public class Given_JsObject : Specification
         // _windowInstance is constructed in Window's context.
         Assert.True(ReferenceEquals(_windowInstance, Window.FromExpression("window")));
     }
+
+    [Observation]
+    public void When_BooleanToJsObjectString()
+    {
+        Assert.Equal("true", JsObject.ToJsObjectString(true));
+        Assert.Equal("false", JsObject.ToJsObjectString(false));
+    }
 }

--- a/tests/Trungnt2910.Browser.Tests/Given_Union.cs
+++ b/tests/Trungnt2910.Browser.Tests/Given_Union.cs
@@ -1,0 +1,33 @@
+﻿namespace Trungnt2910.Browser.Tests;
+
+public class Given_Union : Specification
+{
+    private JsFunc<Union<int, bool>, string> _jsToString = null!;
+    private Union<int, Window> _intOrWindow = null!;
+
+    protected override void EstablishContext()
+    {
+        _jsToString = JsFunc<Union<int, bool>, string>.FromExpression("(a) => a.toString()")!;
+        _intOrWindow = 69;
+    }
+
+    [Observation]
+    public void When_ImplicitConvertToUnion()
+    {
+        Assert.Equal("true", _jsToString.Invoke(true));
+        Assert.Equal("false", _jsToString.Invoke(false));
+        Assert.Equal("-3", _jsToString.Invoke(-3));
+        Assert.Equal("69420", _jsToString.Invoke(69420));
+    }
+
+    [Observation]
+    public void When_ExplicitConvertFromUnion()
+    {
+        Assert.Equal(69, (int)_intOrWindow);
+        _intOrWindow = Window.Instance!;
+        Assert.Equal(Window.Instance!, _intOrWindow);
+        Assert.ThrowsAny<Exception>(() => (int)_intOrWindow);
+        _intOrWindow = 69;
+        Assert.Equal(69, (int)_intOrWindow);
+    }
+}

--- a/tests/Trungnt2910.Browser.Tests/Trungnt2910.Browser.Tests.csproj
+++ b/tests/Trungnt2910.Browser.Tests/Trungnt2910.Browser.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(_BrowserTfm)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- IMPORTANT: This allows xUnit to select the correct test framework. -->
+    <AssemblyAttribute Include="Xunit.TestFrameworkAttribute">
+      <_Parameter1>Trungnt2910.Browser.ObservationFramework.ObservationTestFramework</_Parameter1>
+      <_Parameter2>Trungnt2910.Browser.ObservationFramework</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Trungnt2910.Browser.ObservationFramework\Trungnt2910.Browser.ObservationFramework\Trungnt2910.Browser.ObservationFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Trungnt2910.Browser.Tests/Trungnt2910.Browser.Tests.csproj
+++ b/tests/Trungnt2910.Browser.Tests/Trungnt2910.Browser.Tests.csproj
@@ -15,6 +15,8 @@
       <_Parameter1>Trungnt2910.Browser.ObservationFramework.ObservationTestFramework</_Parameter1>
       <_Parameter2>Trungnt2910.Browser.ObservationFramework</_Parameter2>
     </AssemblyAttribute>
+    <!-- xUnit configuration to enable diagnostic logging for dotnet test. -->
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Trungnt2910.Browser.Tests/Usings.cs
+++ b/tests/Trungnt2910.Browser.Tests/Usings.cs
@@ -1,0 +1,4 @@
+global using Xunit;
+global using Trungnt2910.Browser;
+global using Trungnt2910.Browser.Dom;
+global using Trungnt2910.Browser.ObservationFramework;

--- a/tests/Trungnt2910.Browser.Tests/xunit.runner.json
+++ b/tests/Trungnt2910.Browser.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}


### PR DESCRIPTION
The project now uses the new ObservationFramework for unit testing on Microsoft Edge. Cake scripts and CI has been added to allow running these tests.

This commit also include basic tests for a few basic types.